### PR TITLE
fix: resolve all compiler warnings

### DIFF
--- a/src/deque.mbt
+++ b/src/deque.mbt
@@ -185,12 +185,12 @@ pub fn[A] T::empty() -> T[A] {
 }
 
 ///|
-pub fn[A] T::from_list(xs : @list.T[A]) -> T[A] {
+pub fn[A] T::from_list(xs : @list.List[A]) -> T[A] {
   (List(xs), Tsil::empty())
 }
 
 ///|
-pub fn[A] T::from_rev_list(xs : @list.T[A]) -> T[A] {
+pub fn[A] T::from_rev_list(xs : @list.List[A]) -> T[A] {
   (List::empty(), Tsil(xs))
 }
 

--- a/src/deque_test.mbt
+++ b/src/deque_test.mbt
@@ -651,7 +651,7 @@ test "@immut_deque.takeWhile" {
 ///|
 test "overflow/@immut/list" {
   let iter = Int::until(0, 1 << 20)
-  let lst = @immut/list.from_iter(iter)
+  let lst = @list.from_iter(iter)
   inspect(
     lst.fold(init=0.0, fn(acc, x) { acc + x.to_double() }),
     content="549755289600",

--- a/src/immut_deque.mbti
+++ b/src/immut_deque.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "illusory0x0/immut_deque"
 
 import(
@@ -5,98 +6,71 @@ import(
 )
 
 // Values
-fn[A] append(T[A], T[A]) -> T[A]
 
-fn[A, B] bind(T[A], (A) -> T[B]) -> T[B]
-
-fn[A] cons(T[A], A) -> T[A]
-
-fn[A] drop(T[A], Int) -> T[A]
-
-fn[A] dropWhile(T[A], (A) -> Bool) -> T[A]
-
-fn[A] empty() -> T[A]
-
-fn[A] filter(T[A], (A) -> Bool) -> T[A]
-
-fn[A, B] filter_map(T[A], (A) -> B?) -> T[B]
-
-fn[A, B] foldl(T[A], B, (B, A) -> B) -> B
-
-fn[A, B] foldr(T[A], B, (B, A) -> B) -> B
-
-fn[A] from_iter(Iter[A]) -> T[A]
-
-fn[A] from_list(@list.T[A]) -> T[A]
-
-fn[A] from_rev_list(@list.T[A]) -> T[A]
-
-fn[A] head(T[A]) -> A?
-
-fn[A] init_(T[A]) -> T[A]
-
-fn[A] iter(T[A]) -> Iter[A]
-
-fn[A] join(T[T[A]]) -> T[A]
-
-fn[A] last(T[A]) -> A?
-
-fn[A, B] map(T[A], (A) -> B) -> T[B]
-
-fn[A] of(FixedArray[A]) -> T[A]
-
-fn[A] rev_iter(T[A]) -> Iter[A]
-
-fn[A] reverse(T[A]) -> T[A]
-
-fn[A] singleton(A) -> T[A]
-
-fn[A] snoc(T[A], A) -> T[A]
-
-fn[A] tail(T[A]) -> T[A]
-
-fn[A] take(T[A], Int) -> T[A]
-
-fn[A] takeWhile(T[A], (A) -> Bool) -> T[A]
-
-fn[A] to_array(T[A]) -> Array[A]
-
-fn[A] uncons(T[A]) -> (A, T[A])?
-
-fn[A] unsnoc(T[A]) -> (A, T[A])?
+// Errors
 
 // Types and methods
 type T[A]
 fn[A] T::append(Self[A], Self[A]) -> Self[A]
+fnalias T::append
 fn[A, B] T::bind(Self[A], (A) -> Self[B]) -> Self[B]
+fnalias T::bind
 fn[A] T::cons(Self[A], A) -> Self[A]
+fnalias T::cons
 fn[A] T::drop(Self[A], Int) -> Self[A]
+fnalias T::drop
 fn[A] T::dropWhile(Self[A], (A) -> Bool) -> Self[A]
+fnalias T::dropWhile
 fn[A] T::empty() -> Self[A]
+fnalias T::empty
 fn[A] T::filter(Self[A], (A) -> Bool) -> Self[A]
+fnalias T::filter
 fn[A, B] T::filter_map(Self[A], (A) -> B?) -> Self[B]
+fnalias T::filter_map
 fn[A, B] T::foldl(Self[A], B, (B, A) -> B) -> B
+fnalias T::foldl
 fn[A, B] T::foldr(Self[A], B, (B, A) -> B) -> B
+fnalias T::foldr
 fn[A] T::from_iter(Iter[A]) -> Self[A]
-fn[A] T::from_list(@list.T[A]) -> Self[A]
-fn[A] T::from_rev_list(@list.T[A]) -> Self[A]
+fnalias T::from_iter
+fn[A] T::from_list(@list.List[A]) -> Self[A]
+fnalias T::from_list
+fn[A] T::from_rev_list(@list.List[A]) -> Self[A]
+fnalias T::from_rev_list
 fn[A] T::head(Self[A]) -> A?
+fnalias T::head
 fn[A] T::init_(Self[A]) -> Self[A]
+fnalias T::init_
 fn[A] T::iter(Self[A]) -> Iter[A]
+fnalias T::iter
 fn[A] T::join(Self[Self[A]]) -> Self[A]
+fnalias T::join
 fn[A] T::last(Self[A]) -> A?
+fnalias T::last
 fn[A, B] T::map(Self[A], (A) -> B) -> Self[B]
+fnalias T::map
 fn[A] T::of(FixedArray[A]) -> Self[A]
+fnalias T::of
 fn[A] T::rev_iter(Self[A]) -> Iter[A]
+fnalias T::rev_iter
 fn[A] T::reverse(Self[A]) -> Self[A]
+fnalias T::reverse
 fn[A] T::singleton(A) -> Self[A]
+fnalias T::singleton
 fn[A] T::snoc(Self[A], A) -> Self[A]
+fnalias T::snoc
 fn[A] T::tail(Self[A]) -> Self[A]
+fnalias T::tail
 fn[A] T::take(Self[A], Int) -> Self[A]
+fnalias T::take
 fn[A] T::takeWhile(Self[A], (A) -> Bool) -> Self[A]
+fnalias T::takeWhile
 fn[A] T::to_array(Self[A]) -> Array[A]
+fnalias T::to_array
 fn[A] T::uncons(Self[A]) -> (A, Self[A])?
+fnalias T::uncons
 fn[A] T::unsnoc(Self[A]) -> (A, Self[A])?
+fnalias T::unsnoc
 impl[A : Show] Show for T[A]
 
 // Type aliases

--- a/src/list.mbt
+++ b/src/list.mbt
@@ -30,7 +30,7 @@ fn[A] List::rev_iter(self : List[A]) -> Iter[A] {
 
 ///|
 fn[A] List::append(self : List[A], other : List[A]) -> List[A] {
-  @list.T::concat(self.inner(), other.inner())
+  self.inner() + other.inner()
 }
 
 ///|

--- a/src/tsil.mbt
+++ b/src/tsil.mbt
@@ -35,7 +35,7 @@ fn[A] Tsil::rev_iter(self : Tsil[A]) -> Iter[A] {
 
 ///|
 fn[A] Tsil::append(self : Tsil[A], other : Tsil[A]) -> Tsil[A] {
-  @list.T::concat(other.inner(), self.inner())
+  other.inner() + self.inner()
 }
 
 ///|

--- a/src/types.mbt
+++ b/src/types.mbt
@@ -1,8 +1,8 @@
 ///|
-priv struct List[A](@list.T[A])
+priv struct List[A](@list.List[A])
 
 ///|
-priv struct Tsil[A](@list.T[A])
+priv struct Tsil[A](@list.List[A])
 
 ///|
-type T[A] (List[A], Tsil[A])
+struct T[A]((List[A], Tsil[A]))

--- a/src/types.mbt
+++ b/src/types.mbt
@@ -1,8 +1,8 @@
 ///|
-priv type List[A] @list.T[A]
+priv struct List[A](@list.T[A])
 
 ///|
-priv type Tsil[A] @list.T[A]
+priv struct Tsil[A](@list.T[A])
 
 ///|
 type T[A] (List[A], Tsil[A])


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

- Replace deprecated @list.T with List
- Update newtype syntax to struct syntax for T[A] type
- Replace @immut/list with @list
- Fix List concatenation in Tsil::append to use + operator

All warnings have been resolved while maintaining compatibility and test coverage.