### PR TITLE
Fix MoonBit warnings and ensure project compatibility

### DIFF
--- a/src/deque.mbt
+++ b/src/deque.mbt
@@ -1,10 +1,12 @@
 ///|
+#as_free_fn(cons)
 pub fn[A] T::cons(self : T[A], x : A) -> T[A] {
   let (lst, tsl) = self.0
   (lst.cons(x), tsl)
 }
 
 ///|
+#as_free_fn(append)
 pub fn[A] T::append(self : T[A], other : T[A]) -> T[A] {
   let (lst1, tsl1) = self.0
   let (lst2, tsl2) = other.0
@@ -14,18 +16,21 @@ pub fn[A] T::append(self : T[A], other : T[A]) -> T[A] {
 }
 
 ///|
+#as_free_fn(snoc)
 pub fn[A] T::snoc(self : T[A], x : A) -> T[A] {
   let (lst, tsl) = self.0
   (lst, tsl.snoc(x))
 }
 
 ///|
+#as_free_fn(reverse)
 pub fn[A] T::reverse(self : T[A]) -> T[A] {
   let (lst, tsl) = self.0
   (tsl.reverse(), lst.reverse())
 }
 
 ///|
+#as_free_fn(uncons)
 pub fn[A] T::uncons(self : T[A]) -> (A, T[A])? {
   let (lst, tsl) = self.0
   match lst.0 {
@@ -39,6 +44,7 @@ pub fn[A] T::uncons(self : T[A]) -> (A, T[A])? {
 }
 
 ///|
+#as_free_fn(unsnoc)
 pub fn[A] T::unsnoc(self : T[A]) -> (A, T[A])? {
   let (lst, tsl) = self.0
   match tsl.0 {
@@ -52,12 +58,14 @@ pub fn[A] T::unsnoc(self : T[A]) -> (A, T[A])? {
 }
 
 ///|
+#as_free_fn(map)
 pub fn[A, B] T::map(self : T[A], f : (A) -> B) -> T[B] {
   let (lst, tsl) = self.0
   (lst.0.map(f), tsl.0.map(f))
 }
 
 ///|
+#as_free_fn(foldl)
 pub fn[A, B] T::foldl(self : T[A], z : B, f : (B, A) -> B) -> B {
   let (cons, snoc) = self.0
   let z = cons.foldl(f, z)
@@ -65,6 +73,7 @@ pub fn[A, B] T::foldl(self : T[A], z : B, f : (B, A) -> B) -> B {
 }
 
 ///|
+#as_free_fn(foldr)
 pub fn[A, B] T::foldr(self : T[A], z : B, f : (B, A) -> B) -> B {
   let (cons, snoc) = self.0
   let z = snoc.foldr(z, f)
@@ -72,6 +81,7 @@ pub fn[A, B] T::foldr(self : T[A], z : B, f : (B, A) -> B) -> B {
 }
 
 ///|
+#as_free_fn(bind)
 pub fn[A, B] T::bind(self : T[A], k : (A) -> T[B]) -> T[B] {
   fn step(acc : List[B], a : A) -> List[B] {
     let (lst, tsl) = k(a).0
@@ -85,11 +95,13 @@ pub fn[A, B] T::bind(self : T[A], k : (A) -> T[B]) -> T[B] {
 }
 
 ///|
+#as_free_fn(join)
 pub fn[A] T::join(self : T[T[A]]) -> T[A] {
   self.bind(fn(x) { x })
 }
 
 ///|
+#as_free_fn(iter)
 pub fn[A] T::iter(self : T[A]) -> Iter[A] {
   Iter::new(fn(k) {
     let (lst, tsl) = self.0
@@ -101,6 +113,7 @@ pub fn[A] T::iter(self : T[A]) -> Iter[A] {
 }
 
 ///|
+#as_free_fn(rev_iter)
 pub fn[A] T::rev_iter(self : T[A]) -> Iter[A] {
   Iter::new(fn(k) {
     let (lst, tsl) = self.0
@@ -112,6 +125,7 @@ pub fn[A] T::rev_iter(self : T[A]) -> Iter[A] {
 }
 
 ///|
+#as_free_fn(to_array)
 pub fn[A] T::to_array(self : T[A]) -> Array[A] {
   self.iter().to_array()
 }
@@ -122,28 +136,33 @@ pub impl[A : Show] Show for T[A] with output(xs, logger) {
 }
 
 ///|
+#as_free_fn(filter)
 pub fn[A] T::filter(self : T[A], f : (A) -> Bool) -> T[A] {
   let (lst, tsl) = self.0
   (lst.0.filter(f), tsl.0.filter(f))
 }
 
 ///|
+#as_free_fn(filter_map)
 pub fn[A, B] T::filter_map(self : T[A], f : (A) -> B?) -> T[B] {
   let (lst, tsl) = self.0
   (lst.0.filter_map(f), tsl.0.filter_map(f))
 }
 
 ///|
+#as_free_fn(head)
 pub fn[A] T::head(self : T[A]) -> A? {
   self.uncons().map(x => x.0)
 }
 
 ///|
+#as_free_fn(last)
 pub fn[A] T::last(self : T[A]) -> A? {
   self.unsnoc().map(x => x.0)
 }
 
 ///|
+#as_free_fn(tail)
 pub fn[A] T::tail(self : T[A]) -> T[A] {
   match self.uncons() {
     None => empty()
@@ -152,6 +171,7 @@ pub fn[A] T::tail(self : T[A]) -> T[A] {
 }
 
 ///|
+#as_free_fn(init_)
 pub fn[A] T::init_(self : T[A]) -> T[A] {
   match self.unsnoc() {
     None => empty()
@@ -160,85 +180,61 @@ pub fn[A] T::init_(self : T[A]) -> T[A] {
 }
 
 ///|
+#as_free_fn(take)
 pub fn[A] T::take(self : T[A], n : Int) -> T[A] {
   self.iter().take(n) |> from_iter
 }
 
 ///|
+#as_free_fn(drop)
 pub fn[A] T::drop(self : T[A], n : Int) -> T[A] {
   self.iter().drop(n) |> from_iter
 }
 
 ///|
+#as_free_fn(takeWhile)
 pub fn[A] T::takeWhile(self : T[A], f : (A) -> Bool) -> T[A] {
   self.iter().take_while(f) |> from_iter
 }
 
 ///|
+#as_free_fn(dropWhile)
 pub fn[A] T::dropWhile(self : T[A], f : (A) -> Bool) -> T[A] {
   self.iter().drop_while(f) |> from_iter
 }
 
 ///|
+#as_free_fn(empty)
 pub fn[A] T::empty() -> T[A] {
   (List::empty(), Tsil::empty())
 }
 
 ///|
+#as_free_fn(from_list)
 pub fn[A] T::from_list(xs : @list.List[A]) -> T[A] {
   (List(xs), Tsil::empty())
 }
 
 ///|
+#as_free_fn(from_rev_list)
 pub fn[A] T::from_rev_list(xs : @list.List[A]) -> T[A] {
   (List::empty(), Tsil(xs))
 }
 
 ///|
+#as_free_fn(of)
 pub fn[A] T::of(xs : FixedArray[A]) -> T[A] {
   @list.from_array(xs) |> from_list
 }
 
 ///|
+#as_free_fn(from_iter)
 pub fn[A] T::from_iter(xs : Iter[A]) -> T[A] {
   (List::empty(), @list.from_iter_rev(xs))
 }
 
 ///|
+#as_free_fn(singleton)
 pub fn[A] T::singleton(x : A) -> T[A] {
   (@list.cons(x, @list.empty()), @list.empty())
 }
-
-///|
-pub fnalias T::(
-  append,
-  bind,
-  cons,
-  drop,
-  dropWhile,
-  empty,
-  filter,
-  filter_map,
-  foldl,
-  foldr,
-  from_iter,
-  from_list,
-  from_rev_list,
-  head,
-  init_,
-  iter,
-  join,
-  last,
-  map,
-  of,
-  rev_iter,
-  reverse,
-  singleton,
-  snoc,
-  tail,
-  take,
-  takeWhile,
-  to_array,
-  uncons,
-  unsnoc
-)

--- a/src/deque.mbt
+++ b/src/deque.mbt
@@ -1,13 +1,13 @@
 ///|
 pub fn[A] T::cons(self : T[A], x : A) -> T[A] {
-  let (lst, tsl) = self.inner()
+  let (lst, tsl) = self.0
   (lst.cons(x), tsl)
 }
 
 ///|
 pub fn[A] T::append(self : T[A], other : T[A]) -> T[A] {
-  let (lst1, tsl1) = self.inner()
-  let (lst2, tsl2) = other.inner()
+  let (lst1, tsl1) = self.0
+  let (lst2, tsl2) = other.0
   let lst = lst1
   let tsl = lst2.foldl(Tsil::snoc, tsl1).append(tsl2)
   (lst, tsl)
@@ -15,23 +15,23 @@ pub fn[A] T::append(self : T[A], other : T[A]) -> T[A] {
 
 ///|
 pub fn[A] T::snoc(self : T[A], x : A) -> T[A] {
-  let (lst, tsl) = self.inner()
+  let (lst, tsl) = self.0
   (lst, tsl.snoc(x))
 }
 
 ///|
 pub fn[A] T::reverse(self : T[A]) -> T[A] {
-  let (lst, tsl) = self.inner()
+  let (lst, tsl) = self.0
   (tsl.reverse(), lst.reverse())
 }
 
 ///|
 pub fn[A] T::uncons(self : T[A]) -> (A, T[A])? {
-  let (lst, tsl) = self.inner()
-  match lst.inner() {
+  let (lst, tsl) = self.0
+  match lst.0 {
     More(head, tail~) => Some((head, (List(tail), tsl)))
     Empty =>
-      match tsl.inner().rev() {
+      match tsl.0.rev() {
         More(head, tail~) => Some((head, (List(tail), Tsil::empty())))
         Empty => None
       }
@@ -40,11 +40,11 @@ pub fn[A] T::uncons(self : T[A]) -> (A, T[A])? {
 
 ///|
 pub fn[A] T::unsnoc(self : T[A]) -> (A, T[A])? {
-  let (lst, tsl) = self.inner()
-  match tsl.inner() {
+  let (lst, tsl) = self.0
+  match tsl.0 {
     More(last, tail=init) => Some((last, (lst, Tsil(init))))
     Empty =>
-      match lst.inner().rev() {
+      match lst.0.rev() {
         More(last, tail=init) => Some((last, (List::empty(), Tsil(init))))
         Empty => None
       }
@@ -53,20 +53,20 @@ pub fn[A] T::unsnoc(self : T[A]) -> (A, T[A])? {
 
 ///|
 pub fn[A, B] T::map(self : T[A], f : (A) -> B) -> T[B] {
-  let (lst, tsl) = self.inner()
-  (lst.inner().map(f), tsl.inner().map(f))
+  let (lst, tsl) = self.0
+  (lst.0.map(f), tsl.0.map(f))
 }
 
 ///|
 pub fn[A, B] T::foldl(self : T[A], z : B, f : (B, A) -> B) -> B {
-  let (cons, snoc) = self.inner()
+  let (cons, snoc) = self.0
   let z = cons.foldl(f, z)
   snoc.foldl(z, f)
 }
 
 ///|
 pub fn[A, B] T::foldr(self : T[A], z : B, f : (B, A) -> B) -> B {
-  let (cons, snoc) = self.inner()
+  let (cons, snoc) = self.0
   let z = snoc.foldr(z, f)
   cons.foldr(z, f)
 }
@@ -74,11 +74,11 @@ pub fn[A, B] T::foldr(self : T[A], z : B, f : (B, A) -> B) -> B {
 ///|
 pub fn[A, B] T::bind(self : T[A], k : (A) -> T[B]) -> T[B] {
   fn step(acc : List[B], a : A) -> List[B] {
-    let (lst, tsl) = k(a).inner()
+    let (lst, tsl) = k(a).0
     lst.append(tsl.reverse().append(acc))
   }
 
-  let (lst, tsl) = self.inner()
+  let (lst, tsl) = self.0
   let z = tsl.reverse().foldl(step, List::empty())
   let lst = lst.foldr(z, step)
   (lst, Tsil::empty())
@@ -92,7 +92,7 @@ pub fn[A] T::join(self : T[T[A]]) -> T[A] {
 ///|
 pub fn[A] T::iter(self : T[A]) -> Iter[A] {
   Iter::new(fn(k) {
-    let (lst, tsl) = self.inner()
+    let (lst, tsl) = self.0
     match lst.iter().run(k) {
       IterContinue => tsl.iter().run(k)
       IterEnd => IterEnd
@@ -103,7 +103,7 @@ pub fn[A] T::iter(self : T[A]) -> Iter[A] {
 ///|
 pub fn[A] T::rev_iter(self : T[A]) -> Iter[A] {
   Iter::new(fn(k) {
-    let (lst, tsl) = self.inner()
+    let (lst, tsl) = self.0
     match tsl.rev_iter().run(k) {
       IterContinue => lst.rev_iter().run(k)
       IterEnd => IterEnd
@@ -123,14 +123,14 @@ pub impl[A : Show] Show for T[A] with output(xs, logger) {
 
 ///|
 pub fn[A] T::filter(self : T[A], f : (A) -> Bool) -> T[A] {
-  let (lst, tsl) = self.inner()
-  (lst.inner().filter(f), tsl.inner().filter(f))
+  let (lst, tsl) = self.0
+  (lst.0.filter(f), tsl.0.filter(f))
 }
 
 ///|
 pub fn[A, B] T::filter_map(self : T[A], f : (A) -> B?) -> T[B] {
-  let (lst, tsl) = self.inner()
-  (lst.inner().filter_map(f), tsl.inner().filter_map(f))
+  let (lst, tsl) = self.0
+  (lst.0.filter_map(f), tsl.0.filter_map(f))
 }
 
 ///|
@@ -196,7 +196,7 @@ pub fn[A] T::from_rev_list(xs : @list.List[A]) -> T[A] {
 
 ///|
 pub fn[A] T::of(xs : FixedArray[A]) -> T[A] {
-  @list.of(xs) |> from_list
+  @list.from_array(xs) |> from_list
 }
 
 ///|
@@ -206,7 +206,7 @@ pub fn[A] T::from_iter(xs : Iter[A]) -> T[A] {
 
 ///|
 pub fn[A] T::singleton(x : A) -> T[A] {
-  (@list.construct(x, @list.empty()), @list.empty())
+  (@list.cons(x, @list.empty()), @list.empty())
 }
 
 ///|

--- a/src/deque_test.mbt
+++ b/src/deque_test.mbt
@@ -576,20 +576,20 @@ test "@immut_deque.take/overflow" {
 ///|
 test "@deque.from_iter/empty" {
   let empty_iter : Iter[Int] = Iter::empty()
-  inspect(@deque.from_iter(empty_iter), content="@deque.of([])")
+  inspect(@deque.from_iter(empty_iter), content="@deque.from_array([])")
 }
 
 ///|
 test "@deque.from_iter/single" {
   let single = Iter::singleton(42)
-  inspect(@deque.from_iter(single), content="@deque.of([42])")
+  inspect(@deque.from_iter(single), content="@deque.from_array([42])")
 }
 
 ///|
 test "@deque.from_iter/multiple" {
   let arr = [1, 2, 3, 4, 5]
   let iter = arr.iter()
-  inspect(@deque.from_iter(iter), content="@deque.of([1, 2, 3, 4, 5])")
+  inspect(@deque.from_iter(iter), content="@deque.from_array([1, 2, 3, 4, 5])")
 }
 
 ///|

--- a/src/list.mbt
+++ b/src/list.mbt
@@ -1,50 +1,50 @@
 ///|
 fn[A] List::cons(self : List[A], x : A) -> List[A] {
-  @list.construct(x, self.inner())
+  @list.cons(x, self.0)
 }
 
 ///|
 fn[A] List::reverse(self : List[A]) -> Tsil[A] {
-  self.inner()
+  Tsil(self.0)
 }
 
 ///|
 fn[A, B] List::foldl(self : List[A], f : (B, A) -> B, z : B) -> B {
-  self.inner().fold(f, init=z)
+  self.0.fold(f, init=z)
 }
 
 ///|
 fn[A, B] List::foldr(self : List[A], z : B, f : (B, A) -> B) -> B {
-  self.inner().rev().fold(init=z, f)
+  self.0.rev().fold(init=z, f)
 }
 
 ///|
 fn[A] List::iter(self : List[A]) -> Iter[A] {
-  self.inner().iter()
+  self.0.iter()
 }
 
 ///|
 fn[A] List::rev_iter(self : List[A]) -> Iter[A] {
-  self.inner().rev().iter()
+  self.0.rev().iter()
 }
 
 ///|
 fn[A] List::append(self : List[A], other : List[A]) -> List[A] {
-  self.inner() + other.inner()
+  self.0 + other.0
 }
 
 ///|
 test "append" {
   let xs = [1, 2, 3] |> List::of
   let ys = [4, 5, 6] |> List::of
-  inspect(xs, content="@list.of([1, 2, 3])")
-  inspect(ys, content="@list.of([4, 5, 6])")
-  inspect(xs.append(ys), content="@list.of([1, 2, 3, 4, 5, 6])")
+  inspect(xs, content="@list.from_array([1, 2, 3])")
+  inspect(ys, content="@list.from_array([4, 5, 6])")
+  inspect(xs.append(ys), content="@list.from_array([1, 2, 3, 4, 5, 6])")
 }
 
 ///|
 fn[A] List::of(xs : FixedArray[A]) -> List[A] {
-  xs |> @list.of
+  xs |> @list.from_array
 }
 
 ///|
@@ -54,5 +54,5 @@ fn[A] List::empty() -> List[A] {
 
 ///|
 impl[A : Show] Show for List[A] with output(self, logger) {
-  self.inner().output(logger)
+  self.0.output(logger)
 }

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -1,0 +1,79 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/immut_deque"
+
+import(
+  "moonbitlang/core/list"
+)
+
+// Values
+
+// Errors
+
+// Types and methods
+type T[A]
+fn[A] T::append(Self[A], Self[A]) -> Self[A]
+fnalias T::append
+fn[A, B] T::bind(Self[A], (A) -> Self[B]) -> Self[B]
+fnalias T::bind
+fn[A] T::cons(Self[A], A) -> Self[A]
+fnalias T::cons
+fn[A] T::drop(Self[A], Int) -> Self[A]
+fnalias T::drop
+fn[A] T::dropWhile(Self[A], (A) -> Bool) -> Self[A]
+fnalias T::dropWhile
+fn[A] T::empty() -> Self[A]
+fnalias T::empty
+fn[A] T::filter(Self[A], (A) -> Bool) -> Self[A]
+fnalias T::filter
+fn[A, B] T::filter_map(Self[A], (A) -> B?) -> Self[B]
+fnalias T::filter_map
+fn[A, B] T::foldl(Self[A], B, (B, A) -> B) -> B
+fnalias T::foldl
+fn[A, B] T::foldr(Self[A], B, (B, A) -> B) -> B
+fnalias T::foldr
+fn[A] T::from_iter(Iter[A]) -> Self[A]
+fnalias T::from_iter
+fn[A] T::from_list(@list.List[A]) -> Self[A]
+fnalias T::from_list
+fn[A] T::from_rev_list(@list.List[A]) -> Self[A]
+fnalias T::from_rev_list
+fn[A] T::head(Self[A]) -> A?
+fnalias T::head
+fn[A] T::init_(Self[A]) -> Self[A]
+fnalias T::init_
+fn[A] T::iter(Self[A]) -> Iter[A]
+fnalias T::iter
+fn[A] T::join(Self[Self[A]]) -> Self[A]
+fnalias T::join
+fn[A] T::last(Self[A]) -> A?
+fnalias T::last
+fn[A, B] T::map(Self[A], (A) -> B) -> Self[B]
+fnalias T::map
+fn[A] T::of(FixedArray[A]) -> Self[A]
+fnalias T::of
+fn[A] T::rev_iter(Self[A]) -> Iter[A]
+fnalias T::rev_iter
+fn[A] T::reverse(Self[A]) -> Self[A]
+fnalias T::reverse
+fn[A] T::singleton(A) -> Self[A]
+fnalias T::singleton
+fn[A] T::snoc(Self[A], A) -> Self[A]
+fnalias T::snoc
+fn[A] T::tail(Self[A]) -> Self[A]
+fnalias T::tail
+fn[A] T::take(Self[A], Int) -> Self[A]
+fnalias T::take
+fn[A] T::takeWhile(Self[A], (A) -> Bool) -> Self[A]
+fnalias T::takeWhile
+fn[A] T::to_array(Self[A]) -> Array[A]
+fnalias T::to_array
+fn[A] T::uncons(Self[A]) -> (A, Self[A])?
+fnalias T::uncons
+fn[A] T::unsnoc(Self[A]) -> (A, Self[A])?
+fnalias T::unsnoc
+impl[A : Show] Show for T[A]
+
+// Type aliases
+
+// Traits
+

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -11,66 +11,66 @@ import(
 
 // Types and methods
 type T[A]
+#as_free_fn(append)
 fn[A] T::append(Self[A], Self[A]) -> Self[A]
-fnalias T::append
+#as_free_fn(bind)
 fn[A, B] T::bind(Self[A], (A) -> Self[B]) -> Self[B]
-fnalias T::bind
+#as_free_fn(cons)
 fn[A] T::cons(Self[A], A) -> Self[A]
-fnalias T::cons
+#as_free_fn(drop)
 fn[A] T::drop(Self[A], Int) -> Self[A]
-fnalias T::drop
+#as_free_fn(dropWhile)
 fn[A] T::dropWhile(Self[A], (A) -> Bool) -> Self[A]
-fnalias T::dropWhile
+#as_free_fn(empty)
 fn[A] T::empty() -> Self[A]
-fnalias T::empty
+#as_free_fn(filter)
 fn[A] T::filter(Self[A], (A) -> Bool) -> Self[A]
-fnalias T::filter
+#as_free_fn(filter_map)
 fn[A, B] T::filter_map(Self[A], (A) -> B?) -> Self[B]
-fnalias T::filter_map
+#as_free_fn(foldl)
 fn[A, B] T::foldl(Self[A], B, (B, A) -> B) -> B
-fnalias T::foldl
+#as_free_fn(foldr)
 fn[A, B] T::foldr(Self[A], B, (B, A) -> B) -> B
-fnalias T::foldr
+#as_free_fn(from_iter)
 fn[A] T::from_iter(Iter[A]) -> Self[A]
-fnalias T::from_iter
+#as_free_fn(from_list)
 fn[A] T::from_list(@list.List[A]) -> Self[A]
-fnalias T::from_list
+#as_free_fn(from_rev_list)
 fn[A] T::from_rev_list(@list.List[A]) -> Self[A]
-fnalias T::from_rev_list
+#as_free_fn(head)
 fn[A] T::head(Self[A]) -> A?
-fnalias T::head
+#as_free_fn(init_)
 fn[A] T::init_(Self[A]) -> Self[A]
-fnalias T::init_
+#as_free_fn(iter)
 fn[A] T::iter(Self[A]) -> Iter[A]
-fnalias T::iter
+#as_free_fn(join)
 fn[A] T::join(Self[Self[A]]) -> Self[A]
-fnalias T::join
+#as_free_fn(last)
 fn[A] T::last(Self[A]) -> A?
-fnalias T::last
+#as_free_fn(map)
 fn[A, B] T::map(Self[A], (A) -> B) -> Self[B]
-fnalias T::map
+#as_free_fn(of)
 fn[A] T::of(FixedArray[A]) -> Self[A]
-fnalias T::of
+#as_free_fn(rev_iter)
 fn[A] T::rev_iter(Self[A]) -> Iter[A]
-fnalias T::rev_iter
+#as_free_fn(reverse)
 fn[A] T::reverse(Self[A]) -> Self[A]
-fnalias T::reverse
+#as_free_fn(singleton)
 fn[A] T::singleton(A) -> Self[A]
-fnalias T::singleton
+#as_free_fn(snoc)
 fn[A] T::snoc(Self[A], A) -> Self[A]
-fnalias T::snoc
+#as_free_fn(tail)
 fn[A] T::tail(Self[A]) -> Self[A]
-fnalias T::tail
+#as_free_fn(take)
 fn[A] T::take(Self[A], Int) -> Self[A]
-fnalias T::take
+#as_free_fn(takeWhile)
 fn[A] T::takeWhile(Self[A], (A) -> Bool) -> Self[A]
-fnalias T::takeWhile
+#as_free_fn(to_array)
 fn[A] T::to_array(Self[A]) -> Array[A]
-fnalias T::to_array
+#as_free_fn(uncons)
 fn[A] T::uncons(Self[A]) -> (A, Self[A])?
-fnalias T::uncons
+#as_free_fn(unsnoc)
 fn[A] T::unsnoc(Self[A]) -> (A, Self[A])?
-fnalias T::unsnoc
 impl[A : Show] Show for T[A]
 
 // Type aliases

--- a/src/tsil.mbt
+++ b/src/tsil.mbt
@@ -1,11 +1,11 @@
 ///|
 fn[A] Tsil::snoc(self : Tsil[A], x : A) -> Tsil[A] {
-  @list.construct(x, self.inner())
+  @list.cons(x, self.0)
 }
 
 ///|
 fn[A] Tsil::reverse(self : Tsil[A]) -> List[A] {
-  self.inner()
+  List(self.0)
 }
 
 ///|
@@ -15,27 +15,27 @@ fn[B, A, C] flip(f : (B, A) -> C) -> (A, B) -> C {
 
 ///|
 fn[A, B] Tsil::foldl(self : Tsil[A], z : B, f : (B, A) -> B) -> B {
-  self.inner().rev().fold(f, init=z)
+  self.0.rev().fold(f, init=z)
 }
 
 ///|
 fn[A, B] Tsil::foldr(self : Tsil[A], z : B, f : (B, A) -> B) -> B {
-  self.inner().fold(f, init=z)
+  self.0.fold(f, init=z)
 }
 
 ///|
 fn[A] Tsil::iter(self : Tsil[A]) -> Iter[A] {
-  self.inner().rev().iter()
+  self.0.rev().iter()
 }
 
 ///|
 fn[A] Tsil::rev_iter(self : Tsil[A]) -> Iter[A] {
-  self.inner().iter()
+  self.0.iter()
 }
 
 ///|
 fn[A] Tsil::append(self : Tsil[A], other : Tsil[A]) -> Tsil[A] {
-  other.inner() + self.inner()
+  Tsil(other.0 + self.0)
 }
 
 ///|
@@ -75,5 +75,5 @@ impl[A : Show] Show for Tsil[A] with output(self, logger) {
 
 ///|
 fn[A] Tsil::empty() -> Tsil[A] {
-  @list.empty()
+  Tsil(@list.empty())
 }


### PR DESCRIPTION
## Summary

Updated the MoonBit project to eliminate errors and warnings from `moon check`, ensuring the project is up to date and compatible with the latest MoonBit standards. Also verified that `moon test` works correctly.

## Changes Made

- **src/deque.mbt**: Refactored code to resolve MoonBit warnings and improve type safety
- **src/list.mbt**: Updated implementations to match current MoonBit syntax requirements
- **src/pkg.generated.mbti**: Added comprehensive type information file (79 new lines)
- **src/tsil.mbt**: Fixed syntax issues and updated to current standards

## Implementation Details

The changes focus on:
- Eliminating compilation warnings and errors detected by `moon check`
- Ensuring proper type annotations and declarations
- Adding missing type information in the generated interface file
- Maintaining backward compatibility while updating to current MoonBit standards

## Verification

- Executed `moon fmt` to ensure code formatting consistency
- Executed `moon info` to verify project metadata
- Reviewed git diff to confirm all changes are appropriate
- Verified that `moon test` passes successfully

These updates ensure the project builds cleanly and follows current MoonBit best practices.