### PR TITLE
Fix MoonBit nightly warnings

### DIFF
--- a/src/deque.mbt
+++ b/src/deque.mbt
@@ -121,14 +121,20 @@ pub fn[A] T::to_array(self : T[A]) -> Array[A] {
 }
 
 ///|
-pub impl[A : Show] Show for T[A] with output(xs, logger) {
+pub impl[A : Show] Show for T[A] with fn output(xs, logger) {
   logger.write_iter(xs.iter().iter(), prefix="@deque.of([", suffix="])")
 }
 
 ///|
-pub impl[A : Debug] Debug for T[A] with to_repr(xs) {
-  Repr::opaque_("Deque", Repr::array(xs.to_array().map(fn(x) { to_repr(x) })))
+pub extend T with Show::{to_string, output}
+
+///|
+pub impl[A : Debug] Debug for T[A] with fn to_repr(xs) {
+  Repr::opaque_("Deque", Repr::array(xs.to_array().map(fn(x) { Repr(x) })))
 }
+
+///|
+pub extend T with @debug.Debug::{to_repr}
 
 ///|
 #as_free_fn(filter)
@@ -219,7 +225,7 @@ pub fn[A] T::from_rev_list(xs : @list.List[A]) -> T[A] {
 ///|
 #as_free_fn(of)
 pub fn[A] T::of(xs : FixedArray[A]) -> T[A] {
-  @list.from_array(xs) |> from_list
+  @list.List(xs) |> from_list
 }
 
 ///|

--- a/src/list.mbt
+++ b/src/list.mbt
@@ -44,7 +44,7 @@ test "append" {
 
 ///|
 fn[A] List::of(xs : FixedArray[A]) -> List[A] {
-  xs |> @list.from_array
+  List(@list.List(xs))
 }
 
 ///|

--- a/src/moon.pkg
+++ b/src/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/core/list",
 }
 

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -52,6 +52,7 @@ pub fn[A] T::last(Self[A]) -> A?
 pub fn[A, B] T::map(Self[A], (A) -> B) -> Self[B]
 #as_free_fn(of)
 pub fn[A] T::of(FixedArray[A]) -> Self[A]
+pub fn[A : Show] T::output(Self[A], &Logger) -> Unit
 #as_free_fn(rev_iter)
 pub fn[A] T::rev_iter(Self[A]) -> Iter[A]
 #as_free_fn(reverse)
@@ -68,6 +69,8 @@ pub fn[A] T::take(Self[A], Int) -> Self[A]
 pub fn[A] T::takeWhile(Self[A], (A) -> Bool) -> Self[A]
 #as_free_fn(to_array)
 pub fn[A] T::to_array(Self[A]) -> Array[A]
+pub fn[A : @debug.Debug] T::to_repr(Self[A]) -> @debug.Repr
+pub fn[A : Show] T::to_string(Self[A]) -> String
 #as_free_fn(uncons)
 pub fn[A] T::uncons(Self[A]) -> (A, Self[A])?
 #as_free_fn(unsnoc)


### PR DESCRIPTION
## Summary

Fixes the MoonBit nightly warnings recorded by Community Cakes dashboard run #128.

- [0079] explicitly preserves the existing Show and Debug dot methods for the deque type.
- [0020] migrates deprecated `to_repr` and list construction calls to their nightly-supported forms.
- Updates the tracked interface snapshot without changing deque behavior or public method signatures.

## Verification

Moon `0.1.20260815` / moonc `v0.10.8+ab524e6b4-nightly`; `MOON_IGNORE_PREBUILD=1 MOON_WORK=off`:

- Four-backend `moon check --deny-warn`
- Four-backend `moon test --deny-warn` — 88/88 on each backend
- `moon fmt`, `moon info`, and `git diff --check`

Baseline: Community Cakes dashboard run #128.